### PR TITLE
Evolution proposition following feb 26th call.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,25 @@ Definitions
 The pull-based interface specs:
 
 ```solidity
-interface Oracle {
-function resultFor(bytes32 id) external view returns (uint timestamp, int outcome, int status);
+interface NumericOracle {
+	function valueFor(bytes32 id) external view returns (uint timestamp, int value);
 }
 ```
 
 `resultFor` MUST revert if the result for an `id` is not available yet.
 `resultFor` MUST return the same result for an `id` after that result is available.
+
+If multiple values are stored, this interface should return the latest one.
+
+**Input:**
+
+- `id`: Description of the required value. Should be standard between all providers. *Proposition:* use the `keccak256` hash of a string describing the requested pair*
+	- keccak256("price-eth-usd") → 0x3d8553e168c60bf792b4d74a300ec5bb1d30bb361e76e6e0b718997770eba580
+	- keccak256("price-btc-usd") → 0xaa42585bae5434c899dd8e4be37e1214661c793c1d1cc40a0ea63c9ef702517e
+	- keccak256("price-eth-btc") → 0x1011b9dea6eedbcd54e76d64617d5ff8543929ae5322f839bad4c01007185505
+	- ...
+
+**Output:**
+
+- `timestamp`: Timestamp (in the unix format, with is used by the EVM), of the associated to the returned value.
+- `value`: Latest value available for the requested `id`. To accomodate for decimal values (like prices) this should be multiplied by a big number such as `10**9` or `10**18`. This value should either be standardized as part of the EIP or be part of the `id` using format such as `keccak256("price-btc-usd-9")`.


### PR DESCRIPTION
summary of the discussion:

We need to clarify the input and output of the interface!

- Should the `bytes32 id` be an oracle call identifier, ant thus be implementer specific, in which case we cannot expect to be able to perform the same call on multiple service, which defeats the purpose of a unified interface — or should we use a standard way of querying for prices, which would be compatible with many oracle systems.
→ the latter was prefered by the participants

- Do we need status? The specification says that invalid calls should revert. Any non-reverting call should provide valid values, so having a status seems superfluous. In addition, for a status code to make sense, it has to be standardized between provider, which we are very far from.
→ for now drop the status

- What should we use as a timestamp. Often, prices are averages weighted by volume. Do we consider the beginning of the timeframe considered? The end? The middle?
→ no decision has been made. This could be provider-specific, but we need to make sure everyone is somehow giving similar values.

- The outcome cannot just be an integer rounded value. Price of RLC in DAI is ~0.56 right now, returning 1 or 0 would be terrible, so we need to multiply the values returns by a standardized quantity (`10**9`? `10**18`?).
→ no decision has been made

- the `resultFor(bytes32)` signature might enter in conflict with other methods, including the one for ERC1154 that as a different return type (an serve a different purpose).
→ To avoid collision we propose renaming the function to `valueFor(bytes32)` as it will be used for pricefeeds. Other propositions are welcome.

I'll be working on a PR to the EIP soon. Once we agree on that we should have at least 2 working implementations, and start building an aggregator contract that will return the median of the values provided by ERC2362 compliant endpoint, and expose an ERC2362 endpoint of his own.

We should then move on with public exposure of this solution, hopefully as soon as march 16~20. Early April would be a possible backup timeframe.